### PR TITLE
[FIX] 개별 피드 페이지 오류 수정

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -83,7 +83,7 @@ async function postQuestion(content, subjectId) {
  * @param {string} subjectId - 관련된 서브젝트의 ID
  * @returns {Promise<Object>} - 모든 질문의 데이터
  */
-async function getQuestionList(subjectId, limit = 10, offset = 0) {
+async function getQuestionList(subjectId, limit = 5000, offset = 0) {
   const query = new URLSearchParams({ limit, offset }).toString();
   const path = `${PATHS.SUBJECT}${subjectId}${PATHS.QUESTION}?${query}`;
 

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -65,10 +65,16 @@ function PostPage() {
         await loadKakaoSDK(process.env.REACT_APP_KAKAO_SHARE_API_KEY);
         const question = await fetchGetQuestion(id);
         const subject = await fetchGetSubject(id);
+
+        if (!subject || !question) {
+          navigate('/notFound');
+          return;
+        }
+
         setResult(question);
         setProfile(subject);
       } catch (err) {
-        alert('결과를 불러올 수 없습니다.');
+        alert('결과를 불러올 수 없습니다. 다시 실행해주세요.');
         console.log(err);
         navigate('/list');
 
@@ -183,13 +189,17 @@ function PostPage() {
         <meta property="og:image" content={profile.imageSource} />
       </Helmet>
 
-      <div className="container mx-auto">
+      <div className="container m-[80px] mx-auto">
         <img src={banner} alt="Background_Banner" className={styles.banner} />
         <div className="relative z-10 mt-12 flex flex-col items-center gap-3">
           <Link to="/">
             <img src={logo} alt="OpenMind" className={styles.logo} />
           </Link>
-          <img src={profile.imageSource} alt="ProfileImage" className={styles.profile} />
+          <img
+            src={profile.imageSource}
+            alt="Profile"
+            className={`${styles.profile} text-center`}
+          />
           <h2 className="h2">{profile.name}</h2>
           <div className="flex gap-3">
             <img src={urlShare} alt="url" onClick={handleCopyUrl} className={styles.share} />

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -74,7 +74,7 @@ function PostPage() {
         setResult(question);
         setProfile(subject);
       } catch (err) {
-        alert('결과를 불러올 수 없습니다. 다시 실행해주세요.');
+        alert('결과를 불러올 수 없습니다.');
         console.log(err);
         navigate('/list');
 


### PR DESCRIPTION
## 구현
- [x] 프로필 alt 잘리던 문제 해결
- [x] 유효하지 않은 id로 들어왔을 때 오류 처리
- [x] 페이지 밑에 마진 추가

## 설명
1. 글로벌 스타일로 페이지 밑에 마진 추가하면 메인 페이지에도 밑에 마진이 들어가서 개별 피드 페이지만 마진 주었습니다.
2. 제가 컴퓨터는 윈도우고 휴대폰만 아이폰이라 휴대폰에서 사파리로 열었을 땐 삭제하기가 잘 작동하는데 혹시 어떻게 안 되는지 알 수 있을까요?